### PR TITLE
SEV Fix: Use DJANGO_API_BASE_URL for header art

### DIFF
--- a/docs/header.js
+++ b/docs/header.js
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from "./config.js";
+import { DJANGO_API_BASE_URL } from "./config.js";
 
 export function showSkeletonLoaders() {
   document.querySelectorAll(".skeleton, .skeleton-text").forEach(el => {
@@ -16,7 +16,7 @@ export function hideSkeletonLoaders() {
 
 export async function fetchAndDisplayHeaderArt(genre) {
   try {
-    const response = await fetch(`${API_BASE_URL}/header-art/${genre}`);
+    const response = await fetch(`${DJANGO_API_BASE_URL}/header-art/${genre}`);
     if (!response.ok) {
       throw new Error(`Failed to fetch header art. Status: ${response.status}`);
     }


### PR DESCRIPTION
**Critical production fix**

Changes header art import from `API_BASE_URL` to `DJANGO_API_BASE_URL` to fix broken header art in production.

**Changes:**
- Line 1: Import change  
- Line 19: API endpoint change

**Files changed:** 1  
**Lines changed:** 2 insertions, 2 deletions

🤖 Generated with [Claude Code](https://claude.ai/code)