### PR TITLE
fix: Remove '2' suffix from playlists_etl naming

### DIFF
--- a/.github/workflows/playlist_etl.yml
+++ b/.github/workflows/playlist_etl.yml
@@ -1,4 +1,4 @@
-name: playlists_etl2
+name: playlists_etl
 
 on:
   schedule:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ make test-integration
 # Run tests with coverage
 make test-coverage
 
-# Test playlist ETL pipeline (simulates playlist_etl2 GitHub workflow)
+# Test playlist ETL pipeline (simulates playlist_etl GitHub workflow)
 make test-playlist-etl
 
 # Visual/UI testing

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ test-ci: setup_env
 	source venv/bin/activate && python -m pytest tests/ -v --tb=short --cov=playlist_etl --cov-report=xml -m "not slow"
 
 test-playlist-etl: setup_env
-	@echo "Testing playlist ETL pipeline (simulates playlist_etl2 workflow)..."
+	@echo "Testing playlist ETL pipeline (simulates playlist_etl workflow)..."
 	@set -o allexport; source .env.test; set +o allexport; \
 	source venv/bin/activate && python playlist_etl/main.py
 


### PR DESCRIPTION
## Summary
- Updated GitHub workflow name from `playlists_etl2` to `playlists_etl`
- Updated Makefile comment references from `playlist_etl2` to `playlist_etl`
- Updated documentation references in CLAUDE.md

## Motivation
The "2" suffix in the naming was inconsistent and confusing. This change provides:
- Cleaner, more intuitive naming
- Better consistency across the codebase
- Simplified references in documentation and comments

## Changes
1. **`.github/workflows/playlist_etl.yml`**: Changed workflow name from `playlists_etl2` to `playlists_etl`
2. **`Makefile`**: Updated comment in `test-playlist-etl` target 
3. **`CLAUDE.md`**: Updated documentation comment

## Test plan
- [x] Verified all references to "etl2" have been updated
- [x] Workflow file syntax is valid
- [ ] GitHub Actions workflow will now run with cleaner name

🤖 Generated with [Claude Code](https://claude.ai/code)