### PR TITLE
Fix Railway deployment issues in Dockerfile

### DIFF
--- a/django_backend/Dockerfile
+++ b/django_backend/Dockerfile
@@ -6,15 +6,15 @@ ENV PYDEVD_DISABLE_FILE_VALIDATION=1
 
 WORKDIR /
 
-COPY django_backend/ /
+COPY . /
 
 ENV PYTHONPATH=/
 
 RUN pip install --upgrade pip && pip install -r /requirements.txt
 
-RUN chmod +x /manage.py
+RUN chmod +x manage.py
 
-EXPOSE 8080
+EXPOSE 8000
 EXPOSE 5678
 
-CMD ["python3", "/manage.py", "runserver", "0.0.0.0:8080"]
+CMD ["python3", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
## Summary
- Fixed file copy path in Dockerfile that was causing nested directory issues
- Updated port from 8080 to 8000 (Railway's standard for Django apps)  
- Corrected manage.py path references to work with the fixed file structure

## Test plan
- [ ] Verify Docker build works locally: `docker build -t tunemeld-test django_backend/`
- [ ] Deploy to Railway and confirm deployment succeeds
- [ ] Test that the Django app starts correctly on Railway

🤖 Generated with [Claude Code](https://claude.ai/code)