### PR TITLE
fix: Add missing PLAYLIST_METADATA_COLLECTION constant to config.py

### DIFF
--- a/playlist_etl/config.py
+++ b/playlist_etl/config.py
@@ -13,6 +13,7 @@ RANK_PRIORITY = [
 
 PLAYLIST_ETL_DATABASE = "playlist_etl"
 RAW_PLAYLISTS_COLLECTION = "raw_playlists"
+PLAYLIST_METADATA_COLLECTION = "playlist_metadata"
 TRACK_COLLECTION = "track"
 TRACK_PLAYLIST_COLLECTION = "track_playlist"
 
@@ -23,6 +24,4 @@ APPLE_MUSIC_ALBUM_COVER_CACHE_COLLECTION = "apple_music_album_cover_cache"
 
 # view count vars
 SPOTIFY_ERROR_THRESHOLD = 5
-SPOTIFY_VIEW_COUNT_XPATH = (
-    '(//*[contains(concat(" ", @class, " "), concat(" ", "w1TBi3o5CTM7zW1EB3Bm", " "))])[4]'
-)
+SPOTIFY_VIEW_COUNT_XPATH = '(//*[contains(concat(" ", @class, " "), concat(" ", "w1TBi3o5CTM7zW1EB3Bm", " "))])[4]'


### PR DESCRIPTION
## Summary
- Fixes ImportError: cannot import name 'PLAYLIST_METADATA_COLLECTION' from 'playlist_etl.config'
- Adds missing PLAYLIST_METADATA_COLLECTION constant to playlist_etl/config.py
- Follows existing collection naming pattern ("playlist_metadata")

## Test plan
- [x] Verified import works: `from playlist_etl.config import PLAYLIST_METADATA_COLLECTION`
- [x] Confirmed all key playlist_etl modules import successfully
- [x] Tested that transform_playlist_metadata.py no longer has import errors

🤖 Generated with [Claude Code](https://claude.ai/code)