### PR TITLE
docs: Add Git workflow guidelines to prevent direct main branch pushes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,16 @@ NEVER create files unless they're absolutely necessary for achieving your goal.
 ALWAYS prefer editing an existing file to creating a new one.
 NEVER proactively create documentation files (\*.md) or README files. Only create documentation files if explicitly requested by the User.
 
+## Git Workflow Guidelines
+
+**NEVER push directly to main/master branch unless explicitly requested:**
+
+- ALWAYS use agentree workflow: `agentree -b <branch-name>` before making changes
+- Work in isolated agentree environments to prevent contamination
+- Create PRs for all changes - never commit directly to main
+- Only push to main if the user specifically says "push to main" or "commit to main"
+- Exception: Only push directly to main when explicitly requested by the user
+
 ## Communication Guidelines
 
 **ALWAYS include PR links at the end of messages when available:**


### PR DESCRIPTION
## Summary
Added clear Git workflow guidelines to CLAUDE.md to prevent accidental direct pushes to the main branch.

## Guidelines Added
- **NEVER push directly to main/master** unless explicitly requested by user
- **ALWAYS use agentree workflow** (`agentree -b <branch-name>`) before making changes
- **Create PRs for all changes** - never commit directly to main
- **Work in isolated agentree environments** to prevent contamination
- **Exception**: Only push to main when user specifically says "push to main" or "commit to main"

## Problem Solved
Previously, there were accidental direct pushes to main (like the .gitignore and Makefile changes), which bypassed the PR review process and CI checks.

## Benefits
✅ **Enforces PR workflow**: All changes go through proper review
✅ **Prevents contamination**: Isolated agentree environments keep work clean
✅ **Better CI integration**: All changes trigger proper CI/CD pipeline
✅ **Clear expectations**: Explicit guidelines for when direct main pushes are allowed

## Location
Added to CLAUDE.md under "Git Workflow Guidelines" section in the important instruction reminders.

🤖 Generated with [Claude Code](https://claude.ai/code)