### PR TITLE
fix: Railway production environment loading

### DIFF
--- a/django_backend/core/settings.py
+++ b/django_backend/core/settings.py
@@ -5,10 +5,9 @@ from dotenv import load_dotenv
 
 environment = os.getenv("RAILWAY_ENVIRONMENT", "development")
 
-# Load appropriate environment file
-if environment == "production":
-    load_dotenv(".env.prod")
-else:
+# Load environment file only in development
+# In production (Railway), environment variables are set directly
+if environment != "production":
     load_dotenv(".env.dev")
 
 MONGO_DATA_API_KEY = os.getenv("MONGO_DATA_API_KEY")


### PR DESCRIPTION
## Issue
Railway service returning 502 errors due to:
```
TypeError: name must be an instance of str
```

## Root Cause
Django trying to load `.env.prod` file in production, but Railway doesn't have access to .env files (they're gitignored). This caused `MONGO_DB_NAME` to be `None`.

## Fix
- Only load .env files in development
- In production, Railway provides environment variables directly
- Removed attempt to load non-existent `.env.prod` in production

🤖 Generated with [Claude Code](https://claude.ai/code)