### PR TITLE
fix: Update Django Dockerfile for proper Railway deployment

### DIFF
--- a/django_backend/Dockerfile
+++ b/django_backend/Dockerfile
@@ -4,15 +4,14 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV PYDEVD_DISABLE_FILE_VALIDATION=1
 
-WORKDIR /
+WORKDIR /app
 
-COPY . /
+COPY . /app
 
-ENV PYTHONPATH=/
+ENV PYTHONPATH=/app
 
-RUN pip install --upgrade pip && pip install -r /requirements.txt
+RUN pip install --upgrade pip && pip install -r /app/requirements.txt
 
 EXPOSE 8000
-EXPOSE 5678
 
-CMD ["python3", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["python3", "/app/manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
## Summary

- Update Django Dockerfile to use `/app` as the working directory instead of `/`
- Fix pip install path to use `/app/requirements.txt`
- Remove unnecessary EXPOSE 5678 port
- Update CMD to use absolute path `/app/manage.py`

## Changes Made

- `WORKDIR /` → `WORKDIR /app`
- `COPY . /` → `COPY . /app`
- `ENV PYTHONPATH=/` → `ENV PYTHONPATH=/app`
- `pip install -r /requirements.txt` → `pip install -r /app/requirements.txt`
- Remove `EXPOSE 5678` line
- `CMD ["python3", "manage.py", ...]` → `CMD ["python3", "/app/manage.py", ...]`

## Test Plan

- [ ] Verify Django backend builds successfully on Railway
- [ ] Confirm application starts without path-related errors
- [ ] Check that static files and dependencies are properly loaded
- [ ] Validate that the application responds correctly on port 8000

🤖 Generated with [Claude Code](https://claude.ai/code)