### PR TITLE
Fix MongoDB collection boolean checks to prevent 500 errors

### DIFF
--- a/django_backend/core/views.py
+++ b/django_backend/core/views.py
@@ -64,7 +64,7 @@ def health(request):
 
 
 def get_graph_data(request, genre_name):
-    if not playlists_collection:
+    if playlists_collection is None:
         return create_response(ResponseStatus.ERROR, "Database not available", None)
 
     key = f"graph_data_{genre_name}"
@@ -123,7 +123,7 @@ def get_graph_data(request, genre_name):
 
 
 def get_playlist_data(request, genre_name):
-    if not playlists_collection:
+    if playlists_collection is None:
         return create_response(ResponseStatus.ERROR, "Database not available", None)
 
     try:
@@ -136,7 +136,7 @@ def get_playlist_data(request, genre_name):
 
 
 def get_service_playlist(request, genre_name, service_name):
-    if not transformed_playlists_collection:
+    if transformed_playlists_collection is None:
         return create_response(ResponseStatus.ERROR, "Database not available", None)
 
     try:
@@ -153,7 +153,7 @@ def get_service_playlist(request, genre_name, service_name):
 
 
 def get_last_updated(request, genre_name):
-    if not playlists_collection:
+    if playlists_collection is None:
         return create_response(ResponseStatus.ERROR, "Database not available", None)
 
     try:
@@ -172,7 +172,7 @@ def get_last_updated(request, genre_name):
 
 
 def get_header_art(request, genre_name):
-    if not raw_playlists_collection:
+    if raw_playlists_collection is None:
         return create_response(ResponseStatus.ERROR, "Database not available", None)
 
     try:


### PR DESCRIPTION
## Summary

This PR fixes the critical MongoDB collection boolean check issue that was causing all data endpoints to return 500 errors.

### Problem
Django was crashing on ALL data endpoints with this error:
```
NotImplementedError: Collection objects do not implement truth value testing or bool().
Please compare with None instead: collection is not None
```

### Root Cause
MongoDB Collection objects can't be used in boolean context with `if not collection:` syntax.

### Solution
Changed all instances of `if not collection:` to `if collection is None:` in the following functions:
- `get_graph_data()` - Line 67
- `get_playlist_data()` - Line 126  
- `get_service_playlist()` - Line 139
- `get_last_updated()` - Line 156
- `get_header_art()` - Line 175

### Test plan
- [ ] Deploy to Railway and verify no 500 errors
- [ ] Test all data endpoints return 200 status
- [ ] Verify frontend loads data instead of "Loading..."
- [ ] Check Railway logs show no MongoDB boolean errors

### Affected Endpoints
- `/playlist-data/edm`
- `/last-updated/edm`
- `/header-art/edm`
- `/service-playlist/edm/spotify`
- `/graph-data/edm`

🤖 Generated with [Claude Code](https://claude.ai/code)