### PR TITLE
Add EDM events endpoint

### DIFF
--- a/django_backend/core/urls.py
+++ b/django_backend/core/urls.py
@@ -31,4 +31,9 @@ urlpatterns = [
         views.get_header_art,
         name="get_header_art_by_genre",
     ),
+    path(
+        "edm-events/",
+        views.get_edm_events,
+        name="get_edm_events",
+    ),
 ]


### PR DESCRIPTION
- Add get_edm_events view that fetches data from GitHub
- Add URL route for /edm-events/ endpoint
- Include caching for improved performance
- Fetch events from AidanJaghab/Beatmap repository
- Lemme push changes 
-